### PR TITLE
Hash router debugs

### DIFF
--- a/starter-frontend/package.json
+++ b/starter-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-notes",
-  "homepage": "https://hcp-uw.github.io/",
+  "homepage": "https://hcp-uw.github.io/green-notes",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/starter-frontend/src/components/auth/Register.tsx
+++ b/starter-frontend/src/components/auth/Register.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../../contexts/AuthContext'
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from 'react';
 import { auth } from '../../config/firebase';
+import { FetchRoute } from '../file-navigation/routes';
 
 // Returns the regester form for making new accounts
 export default function RegisterForm() {
@@ -67,7 +68,7 @@ export default function RegisterForm() {
               body: JSON.stringify(body)
             };
 
-            fetch("http://localhost:3001/createAccount", payloadHeader)
+            fetch(FetchRoute+"/createAccount", payloadHeader)
 
           } catch (e) {
             console.log(e);

--- a/starter-frontend/src/components/editor/EditModal.tsx
+++ b/starter-frontend/src/components/editor/EditModal.tsx
@@ -1,6 +1,7 @@
 import { useState, ChangeEvent, useEffect } from "react";
 import { auth } from "../../config/firebase";
 import { DetailsData } from "../../pages/editor/editor";
+import { FetchRoute } from "../file-navigation/routes";
 
 type EditModalProps = {
     isEditing: boolean,
@@ -176,7 +177,7 @@ const EditModal = ({isEditing, setIsEditing, name, givenClass, teacher, year, ta
           
                 // Fetches the /getFolderContents. The string in the encodeURIComponent is the route
                 // and the payload header is necessary stuff for server authentication
-                fetch("http://localhost:3001/saveDetails", payloadHeader)
+                fetch(FetchRoute+"/saveDetails", payloadHeader)
                     .then((res) => {
                         res.json().then((val) => saveResponse(val))
                           .catch(() => console.error("error fetching /saveDetails: 200 response"))

--- a/starter-frontend/src/components/editor/TextEditor.tsx
+++ b/starter-frontend/src/components/editor/TextEditor.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { Editor } from '@tinymce/tinymce-react';
 import { Editor as TinyMCEEditor } from 'tinymce';
 import { auth } from '../../config/firebase';
+import { FetchRoute } from '../file-navigation/routes';
 
 type TextEditorProps = {
   initContent: string,
@@ -88,7 +89,7 @@ const doSave = async (content: string, route: string, setIsLoading: React.Dispat
 
     // Fetches the /getFolderContents. The string in the encodeURIComponent is the route
     // and the payload header is necessary stuff for server authentication
-    fetch("http://localhost:3001/saveDoc", payloadHeader)
+    fetch(FetchRoute+"/saveDoc", payloadHeader)
         .then(() => {
           setContent(content);
           setCurrContent(content);

--- a/starter-frontend/src/components/file-navigation/NoteThumbnails.tsx
+++ b/starter-frontend/src/components/file-navigation/NoteThumbnails.tsx
@@ -1,5 +1,6 @@
-// import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ThumbnailInfo } from './routes';
+import { Link } from 'react-router-dom';
 
 
 type NoteThumbnailProps = {
@@ -34,7 +35,7 @@ function NoteThumbnail({title, text, route, navigate}: NoteThumbnailProps): JSX.
         // Later make into
         // <Link to={`../note/${id}`} className="link">
         <div>
-            {/* <Link to={`../note`} className="link">
+            {/* <Link to={`/note`} state={{ route: route}} className="link">
                 <span className="thumbnail-click"></span>
             </Link> */}
             <button onClick={() => navigate(route)}className="folder-link">
@@ -59,11 +60,12 @@ type NotesProps = {data: ThumbnailInfo[], location: string, areTemps: boolean, e
 
 export default function NoteThumbnails({data, location, areTemps, email}: NotesProps): JSX.Element {
 
-    // const navigate = useNavigate();
+    const navigate = useNavigate();
     const linkToNote = (route: string): void => {
 
         // navigate("/note?route=" + encodeURIComponent(route))
-        window.open("/note?route="+encodeURIComponent(route), "_blank", "noreferrer")
+        navigate("/note", {state: {route: route}})
+        // window.open("/#/note?route="+encodeURIComponent(route), "_blank", "noreferrer")
     };
 
     const notes: JSX.Element[] = [];

--- a/starter-frontend/src/components/file-navigation/routes.tsx
+++ b/starter-frontend/src/components/file-navigation/routes.tsx
@@ -46,3 +46,7 @@ export type NoteInfo = {name: string, route: string, body: string, kind: "folder
 export const isRecord = (val: unknown): val is Record<string, unknown> => {
     return val !== null && typeof val === "object";
   };
+
+
+export const FetchRoute: string = "http://localhost:3001";
+// export const FetchRoute: string = "https://green-notes.onrender.com";

--- a/starter-frontend/src/components/personal/Create.tsx
+++ b/starter-frontend/src/components/personal/Create.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, MouseEvent } from 'react'
 import { useState, useEffect } from 'react';
 import '../file-navigation/Navigation.css';
 import './Create.css';
-import { route, nil, concat, isRecord, ThumbnailInfo } from '../file-navigation/routes';
+import { route, nil, concat, isRecord, ThumbnailInfo, FetchRoute } from '../file-navigation/routes';
 import { auth } from '../../config/firebase';
 import { useNavigate } from 'react-router-dom';
 import { getNoteContents, NoteData } from '../../pages/notes/notes';
@@ -101,7 +101,7 @@ const Create = ({ isMaking, onMake, isTemp, givenPath, eRoute, email, temps } : 
           
                 // Fetches the /getFolderContents. The string in the encodeURIComponent is the route
                 // and the payload header is necessary stuff for server authentication
-                fetch("http://localhost:3001/createNote", payloadHeader)
+                fetch(FetchRoute+"/createNote", payloadHeader)
                     .then((res) => {
                         res.json().then((val) => createResponse(val, route))
                           .catch(() => console.error("error fetching /createNote: 200 response"))

--- a/starter-frontend/src/components/personal/FolderModal.tsx
+++ b/starter-frontend/src/components/personal/FolderModal.tsx
@@ -1,6 +1,7 @@
 import { route, concat, nil } from "../file-navigation/routes"
 import { useState, useEffect, ChangeEvent } from "react"
 import { auth } from "../../config/firebase"
+import { FetchRoute } from "../file-navigation/routes"
 
 type FolderModalProps = {
     isMakingFolder: boolean;
@@ -61,7 +62,7 @@ const FolderModal = ({isMakingFolder, onMakeFolder, givenPath, eRoute} : FolderM
           
                 // Fetches the /getFolderContents. The string in the encodeURIComponent is the route
                 // and the payload header is necessary stuff for server authentication
-                fetch("http://localhost:3001/createFolder", payloadHeader)
+                fetch(FetchRoute+"/createFolder", payloadHeader)
                     .then(() => window.location.reload())
                     .catch(() => console.error("Error fetching /createFolder: Failed to connect to server"));
                 

--- a/starter-frontend/src/pages/collaboration/collaboration.tsx
+++ b/starter-frontend/src/pages/collaboration/collaboration.tsx
@@ -3,7 +3,7 @@ import NoteThumbnails from "../../components/file-navigation/NoteThumbnails";
 import SearchBar from "../../components/file-navigation/SearchBar";
 import { ThumbnailInfo } from '../../components/file-navigation/routes';
 import { auth } from '../../config/firebase';
-import { isRecord } from '../../components/file-navigation/routes';
+import { isRecord, FetchRoute } from '../../components/file-navigation/routes';
 
 export default function Collaboration(): JSX.Element {
     const params: URLSearchParams = new URLSearchParams(window.location.search);
@@ -87,7 +87,7 @@ export default function Collaboration(): JSX.Element {
                 searchChecked = search.trim();
             }
 
-            let route: string = "http://localhost:3001/getShared?";
+            let route: string = FetchRoute+"/getShared?";
             route += "&tags="+encodeURIComponent(tagsChecked);
             route += "&class="+encodeURIComponent(classChecked);
             route += "&teacher="+encodeURIComponent(teacherChecked);

--- a/starter-frontend/src/pages/editor/editor.tsx
+++ b/starter-frontend/src/pages/editor/editor.tsx
@@ -11,6 +11,7 @@ import ShareModal from "../../components/editor/ShareModal";
 import DeleteButton from "../../components/editor/DeleteButton";
 import DeleteModal from "../../components/editor/DeleteModal";
 import { useLocation } from "react-router-dom";
+import { FetchRoute } from "../../components/file-navigation/routes";
 
 
 export type DetailsData = {
@@ -104,7 +105,7 @@ export function Note(): JSX.Element {
                     body: JSON.stringify(body)
                   };
 
-                  fetch("http://localhost:3001/shareDoc", payloadHeader)
+                  fetch(FetchRoute+"/shareDoc", payloadHeader)
                     .then((a) => {
                         setIsLoading(false);
                         setIsSharing(false);
@@ -134,7 +135,7 @@ export function Note(): JSX.Element {
                   method: "DELETE"
                 };
     
-                fetch("http://localhost:3001/deleteDoc?route="+encodeURIComponent(route), payloadHeader)
+                fetch(FetchRoute+"/deleteDoc?route="+encodeURIComponent(route), payloadHeader)
                     .then((res) => {
                         console.log(res.status);
                         navigate("/Notes");

--- a/starter-frontend/src/pages/editor/editor.tsx
+++ b/starter-frontend/src/pages/editor/editor.tsx
@@ -9,7 +9,8 @@ import EditModal from "../../components/editor/EditModal";
 import ShareButton from "../../components/editor/ShareButton";
 import ShareModal from "../../components/editor/ShareModal";
 import DeleteButton from "../../components/editor/DeleteButton";
-import DeleteModal from "../../components/editor/DeleteModal"
+import DeleteModal from "../../components/editor/DeleteModal";
+import { useLocation } from "react-router-dom";
 
 
 export type DetailsData = {
@@ -47,8 +48,10 @@ export function Note(): JSX.Element {
     const navigate = useNavigate();
 
     // Window params, for now just for the "route" param
-    const params: URLSearchParams = new URLSearchParams(window.location.search);
-    const route: string | null = params.get("route");
+    // const params: URLSearchParams = new URLSearchParams(window.location.search);
+    // const route: string | null = params.get("route");
+    const location = useLocation();
+    const route = location.state.route;
 
     // Response for when the call is succesful
     const fetchResponse = (noteData: NoteData, route: string) => {
@@ -117,7 +120,7 @@ export function Note(): JSX.Element {
 
     const doDeleteClick = async (): Promise<void> => {
         setIsLoading(true);
-        if (route !== null) {
+        if (typeof route === "string") {
             try {
 
                 const user = auth.currentUser;
@@ -147,9 +150,9 @@ export function Note(): JSX.Element {
     // On initial load and when auth.currentUser changes.
     // The second case should never be a possibility without changing pages anyways
     useEffect(() => {
-        if (route === null) {
+        if (typeof route !== "string") {
             console.log("no route given");
-            navigate("/Notes")
+            // navigate("/notes")
         } else {
 
             const user = auth.currentUser;
@@ -172,7 +175,7 @@ export function Note(): JSX.Element {
         }
     }, [route])
 
-    if (route === null) {
+    if (typeof route !== "string") {
         return <>error</>
     }
 

--- a/starter-frontend/src/pages/notes/notes.tsx
+++ b/starter-frontend/src/pages/notes/notes.tsx
@@ -8,7 +8,7 @@ import Create from "../../components/personal/Create";
 import NewFolder from '../../components/personal/NewFolder';
 import FolderModal from '../../components/personal/FolderModal';
 import { auth } from "../../config/firebase";
-import { route, nil, cons, ThumbnailInfo, isRecord, rev, concat } from '../../components/file-navigation/routes';
+import { route, nil, cons, ThumbnailInfo, isRecord, rev, concat, FetchRoute } from '../../components/file-navigation/routes';
 import { User } from "firebase/auth";
 import DeleteFolderButton from '../../components/personal/DeleteFolderButton';
 import DeleteFolderModal from '../../components/personal/DeleteFolderModal';
@@ -155,7 +155,7 @@ export function Notes(): JSX.Element {
         
             // Fetches the /getFolderContents. The string in the encodeURIComponent is the route
             // and the payload header is necessary stuff for server authentication
-            fetch("http://localhost:3001/getFolderContents?route="+encodeURIComponent(route), payloadHeader)
+            fetch(FetchRoute+"/getFolderContents?route="+encodeURIComponent(route), payloadHeader)
                 .then((res) => {
                     res.json().then((val) => doTempResponse(val, route))}) 
                 .catch(() => console.error("Error fetching /getFolderContents: Failed to connect to server"));
@@ -197,7 +197,7 @@ export function Notes(): JSX.Element {
               
                 //     // Fetches the /getFolderContents. The string in the encodeURIComponent is the route
                 //     // and the payload header is necessary stuff for server authentication
-                //     fetch("http://localhost:3001/getFolderContents?route="+encodeURIComponent(route), payloadHeader)
+                //     fetch(FetchRoute+"/getFolderContents?route="+encodeURIComponent(route), payloadHeader)
                 //         .then((res) => {
                 //             res.json().then((val) => doTempResponse(val, route))}) 
                 //         .catch(() => console.error("Error fetching /getFolderContents: Failed to connect to server"));
@@ -388,7 +388,7 @@ const getFolderContents = async (route: string, iD: string, name: string, cb: Fo
   
         // Fetches the /getFolderContents. The string in the encodeURIComponent is the route
         // and the payload header is necessary stuff for server authentication
-        fetch("http://localhost:3001/getFolderContents?route="+encodeURIComponent(route), payloadHeader)
+        fetch(FetchRoute+"/getFolderContents?route="+encodeURIComponent(route), payloadHeader)
             .then((res) => { // If the intial call works
                 if (res.status === 200) { // If the status is good
                     // Currently parseFolderInfo just returns an array of ThumbnailInfo, but doesn't do anything with it yet, no update happens on the page
@@ -497,7 +497,7 @@ export const getNoteContents = async (route: string, cb: NoteCallback): Promise<
   
         // Fetches the /getNote. The string in the encodeURIComponent is the route
         // and the payload header is necessary stuff for server authentication
-        fetch("http://localhost:3001/getNote?route="+encodeURIComponent(route), payloadHeader)
+        fetch(FetchRoute+"/getNote?route="+encodeURIComponent(route), payloadHeader)
             .then((res) => { // If the intial call works
                 if (res.status === 200) { // If the status is good
                     // Currently parseNoteInfo just returns the body in a string, but doesn't do anything with it yet, no update happens on the page


### PR DESCRIPTION
Small merge request, main changes are:
- At every fetch request uses the FetchRoute string which is imported from starter-frontend/src/components/file-navigation/routes.tsx. Main purpose is so if you want to change where you are making the fetch request to (localhost vs hosted server) it's easy to change
- Minor fixes to allow the text editor page to still work with hash router
- Changed "homepage" in package.json to not be in the hcp github pages main route